### PR TITLE
Handle whitespace in dirname path for powershell

### DIFF
--- a/lib/download.js
+++ b/lib/download.js
@@ -175,6 +175,8 @@ async function getAssetFromGithubApi(opts, assetName, downloadFolder) {
 
 function unzipWindows(zipPath, destinationDir) {
     return new Promise((resolve, reject) => {
+        zipPath = sanitizePathForPowershell(zipPath);
+        destinationDir = sanitizePathForPowershell(destinationDir);
         const expandCmd = 'powershell -ExecutionPolicy Bypass -Command Expand-Archive ' + ['-Path', zipPath, '-DestinationPath', destinationDir, '-Force'].join(' ');
         child_process.exec(expandCmd, (err, _stdout, stderr) => {
             if (err) {
@@ -194,9 +196,15 @@ function unzipWindows(zipPath, destinationDir) {
     });
 }
 
+// Handle whitespace in filepath as powershell split's path with whitespaces
+function sanitizePathForPowershell(path) {
+    path = path.replace(' ', '` '); // replace whitespace with "` " as solution provided here https://stackoverflow.com/a/18537344/7374562
+    return path;
+}
+
 function untar(zipPath, destinationDir) {
     return new Promise((resolve, reject) => {
-        const unzipProc = child_process.spawn('tar', ['xvf', zipPath, '-C', destinationDir], { stdio: 'inherit'});
+        const unzipProc = child_process.spawn('tar', ['xvf', zipPath, '-C', destinationDir], { stdio: 'inherit' });
         unzipProc.on('error', err => {
             reject(err);
         });
@@ -254,7 +262,7 @@ module.exports = async opts => {
         console.log('Deleting invalid download cache');
         try {
             await fsUnlink(assetDownloadPath);
-        } catch (e) { }
+        } catch (e) {}
 
         throw e;
     }
@@ -270,7 +278,7 @@ module.exports = async opts => {
 
         try {
             await fsUnlink(assetDownloadPath);
-        } catch (e) { }
+        } catch (e) {}
 
         throw e;
     }


### PR DESCRIPTION
post installation script fails if the destination directory contains the white space within it. This is because powershell splits the path supplied as argument even if enclosed with double quotes.

Applied the solution as suggested [here](https://stackoverflow.com/a/18537344/7374562).

