### PR TITLE
Fix postinstall failing with whitespace in path name.

### DIFF
--- a/lib/download.js
+++ b/lib/download.js
@@ -177,7 +177,7 @@ function unzipWindows(zipPath, destinationDir) {
     return new Promise((resolve, reject) => {
         zipPath = sanitizePathForPowershell(zipPath);
         destinationDir = sanitizePathForPowershell(destinationDir);
-        const expandCmd = 'powershell -ExecutionPolicy Bypass -Command Expand-Archive ' + ['-Path', zipPath, '-DestinationPath', destinationDir, '-Force'].join(' ');
+        const expandCmd = 'powershell -ExecutionPolicy Bypass -Command Expand-Archive ' + ['-Path', `'${zipPath}'`, '-DestinationPath', `'${destinationDir}'`, '-Force'].join(' ');
         child_process.exec(expandCmd, (err, _stdout, stderr) => {
             if (err) {
                 reject(err);


### PR DESCRIPTION
#3 didn't quite fix the issue for me.
This one fixes #2