### PR TITLE
PowerShell information for windows 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,8 @@ const { rgPath } = require('vscode-ripgrep');
 ### Dev note
 
 Runtime dependencies are not allowed in this project. This code runs on postinstall, and any dependencies would only be needed for postinstall, but they would have to be declared as `dependencies`, not `devDependencies`. Then if they were not cleaned up manually, they would end up being included in any project that uses this.
+
+### Windows Power Shell for Windows 7
+- Wont Work for Power Shell 2
+- Need Latest Power Shell 5.1 
+- Get latest [Windows Managment Framework](https://www.microsoft.com/en-us/download/details.aspx?id=54616)


### PR DESCRIPTION
I hope that I can save some one else an entire day of frustration that I had. Every time I tried to yarn install vscode packages to it would stall on vscode-ripgrep with no error. I  went through major commits from the vs code repo and discovered the exact commit. https://github.com/microsoft/vscode/commits/44d410567333dfbd9da5eab6f56bb2c83c31412e where trouble started for me.

I found posts from others with my same problem setup and details. 
https://github.com/microsoft/vscode/issues/77717

Version 1.3.1 of vscode-ripgrep worked great but not the latetest. After investigating the code and comparing the two I discovered that the latest version was using a powershell script. The file did not seem to close after child_process.exec executed the shell script. I investigated and found this post. https://github.com/nodejs/node/issues/25645 

After upgrading to powershell 5.1 the package now works and I wanted to share and update so That it can save some one else this frustration.