### PR TITLE
Add s390x support

### DIFF
--- a/lib/postinstall.js
+++ b/lib/postinstall.js
@@ -16,7 +16,7 @@ if (forceInstall) {
     console.log('--force, ignoring caches');
 }
 
-const VERSION = 'v11.0.1-2';
+const VERSION = 'v11.0.1-4';
 const BIN_PATH = path.join(__dirname, '../bin');
 
 process.on('unhandledRejection', (reason, promise) => {
@@ -38,6 +38,7 @@ function getTarget() {
                 arch === 'arm' ? 'arm-unknown-linux-gnueabihf' :
                 arch === 'arm64' ? 'aarch64-unknown-linux-gnu' :
                 arch === 'ppc64' ? 'powerpc64le-unknown-linux-gnu' :
+                arch === 's390x' ? 's390x-unknown-linux-gnu' :
                     'i686-unknown-linux-musl'
         default: throw new Error('Unknown platform: ' + os.platform());
     }


### PR DESCRIPTION
This PR is in continuation with the microsoft/ripgrep-prebuilt#2 to enable s390x support for [eclipse/che-theia](https://github.com/eclipse/che-theia).

https://github.com/microsoft/ripgrep-prebuilt/pull/2#issuecomment-638594197
>hey @roblourens , so we need this to enable eclipse/che-theia builds on s390x arch which needs ripgrep-prebuilt invoked via https://github.com/microsoft/vscode-ripgrep/blob/master/lib/postinstall.js#L41.