### PR TITLE
fix android platform

### DIFF
--- a/lib/postinstall.js
+++ b/lib/postinstall.js
@@ -34,6 +34,7 @@ function getTarget() {
             return arch === 'x64' ? 'x86_64-pc-windows-msvc' :
                 arch === 'arm' ? 'aarch64-pc-windows-msvc' :
                 'i686-pc-windows-msvc';
+        case 'android':
         case 'linux':
             return arch === 'x64' ? 'x86_64-unknown-linux-musl' :
                 arch === 'arm' ? 'arm-unknown-linux-gnueabihf' :


### PR DESCRIPTION
when use [cdr/code-server](https://github.com/cdr/code-server) with termux on android.
search feature is not work because of missing `bin/rg`