### PR TITLE
Pass proxy to PowerShell request

### DIFF
--- a/lib/download.js
+++ b/lib/download.js
@@ -41,6 +41,9 @@ function downloadWin(url, dest, opts) {
         if (userAgent) {
             iwrCmd += ' -UserAgent ' + userAgent;
         }
+        if (opts.proxy) {
+            iwrCmd += ' -Proxy ' + opts.proxy;
+        }
 
         iwrCmd = `powershell "${iwrCmd}"`;
 
@@ -61,7 +64,8 @@ function download(_url, dest, opts) {
         var HttpsProxyAgent = require('https-proxy-agent');
         opts = {
             ...opts,
-            "agent": new HttpsProxyAgent(proxy)
+            "agent": new HttpsProxyAgent(proxy),
+            proxy
         };
     }
 


### PR DESCRIPTION
Currently the PowerShell request is always executed without considering the configured proxy. This change passes on the proxy if it is set.