### PR TITLE
Update to ripgrep-prebuilt to v13.0.0-4

### DIFF
--- a/lib/postinstall.js
+++ b/lib/postinstall.js
@@ -18,7 +18,7 @@ if (forceInstall) {
     console.log('--force, ignoring caches');
 }
 
-const VERSION = 'v13.0.0-2';
+const VERSION = 'v13.0.0-4';
 const BIN_PATH = path.join(__dirname, '../bin');
 
 process.on('unhandledRejection', (reason, promise) => {


### PR DESCRIPTION
The previously used v13.0.0-2 build was missing ppc64le (PowerPC)
and s390 binaries due to a switch from Travis to Azure Pipelines.
v13.0.0-4 includes those platforms again.

See also https://github.com/microsoft/ripgrep-prebuilt/pull/13