### PR TITLE
bump ripgrep-prebuild version and force musl build for arm64

### DIFF
--- a/lib/postinstall.js
+++ b/lib/postinstall.js
@@ -18,25 +18,12 @@ if (forceInstall) {
     console.log('--force, ignoring caches');
 }
 
-const VERSION = 'v13.0.0-4';
+const VERSION = 'v13.0.0-7';
 const BIN_PATH = path.join(__dirname, '../bin');
 
 process.on('unhandledRejection', (reason, promise) => {
     console.log('Unhandled rejection: ', promise, 'reason:', reason);
 });
-
-async function isMusl() {
-    let stderr;
-    try {
-        stderr = (await exec('ldd --version')).stderr;
-    } catch (err) {
-        stderr = err.stderr;
-    }
-    if(stderr.indexOf('musl') > -1) {
-        return true;
-    }
-    return false;
-}
 
 async function getTarget() {
     const arch = process.env.npm_config_arch || os.arch();
@@ -53,7 +40,7 @@ async function getTarget() {
             return arch === 'x64' ? 'x86_64-unknown-linux-musl' :
                 arch === 'arm' ? 'arm-unknown-linux-gnueabihf' :
                 arch === 'armv7l' ? 'arm-unknown-linux-gnueabihf' :
-                arch === 'arm64' ? await isMusl() ? 'aarch64-unknown-linux-musl' : 'aarch64-unknown-linux-gnu' :
+                arch === 'arm64' ? 'aarch64-unknown-linux-musl':
                 arch === 'ppc64' ? 'powerpc64le-unknown-linux-gnu' :
                 arch === 's390x' ? 's390x-unknown-linux-gnu' :
                     'i686-unknown-linux-musl'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vscode/ripgrep",
-  "version": "1.14.2",
+  "version": "1.15.0",
   "description": "A module for using ripgrep in a Node project",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",


### PR DESCRIPTION
Fixes #34

Also reduces the size of the ripgrep executable for some architectures