### PR TITLE
Change postinstall.js for Power (ppc64le) to force the powerpc64le-unknown-linux-gnu target to use old build.

### DIFF
--- a/lib/postinstall.js
+++ b/lib/postinstall.js
@@ -19,7 +19,7 @@ if (forceInstall) {
 }
 
 const VERSION = 'v13.0.0-10';
-const ARM32_LINUX_VERSION = 'v13.0.0-4';// use this for arm-unknown-linux-gnueabihf until we can fix https://github.com/microsoft/ripgrep-prebuilt/issues/24
+const MULTI_ARCH_LINUX_VERSION = 'v13.0.0-4';// use this for arm-unknown-linux-gnueabihf and powerpc64le-unknown-linux-gnu until we can fix https://github.com/microsoft/ripgrep-prebuilt/issues/24 and https://github.com/microsoft/ripgrep-prebuilt/issues/32 respectively.
 const BIN_PATH = path.join(__dirname, '../bin');
 
 process.on('unhandledRejection', (reason, promise) => {
@@ -62,7 +62,7 @@ async function main() {
 
     const target = await getTarget();
     const opts = {
-        version: target === "arm-unknown-linux-gnueabihf" ? ARM32_LINUX_VERSION: VERSION,
+        version: target === "arm-unknown-linux-gnueabihf" || target === "powerpc64le-unknown-linux-gnu" ? MULTI_ARCH_LINUX_VERSION: VERSION,
         token: process.env['GITHUB_TOKEN'],
         target: await getTarget(),
         destDir: BIN_PATH,


### PR DESCRIPTION
Fixes [microsoft/ripgrep-prebuilt#32](https://github.com/microsoft/ripgrep-prebuilt/issues/32) for vscode for Power(ppc64le).