### PR TITLE
Update postinstall.js for s390x to allow Z to install an earlier build

### DIFF
--- a/lib/postinstall.js
+++ b/lib/postinstall.js
@@ -62,7 +62,7 @@ async function main() {
 
     const target = await getTarget();
     const opts = {
-        version: target === "arm-unknown-linux-gnueabihf" || target === "powerpc64le-unknown-linux-gnu" ? MULTI_ARCH_LINUX_VERSION: VERSION,
+        version: target === "arm-unknown-linux-gnueabihf" || target === "powerpc64le-unknown-linux-gnu" || target === "s390x-unknown-linux-gnu" ? MULTI_ARCH_LINUX_VERSION: VERSION,
         token: process.env['GITHUB_TOKEN'],
         target: await getTarget(),
         destDir: BIN_PATH,


### PR DESCRIPTION
Update postinstall.js for s390x to allow Z to install an earlier build