### PR TITLE
fix long download

### DIFF
--- a/lib/download.js
+++ b/lib/download.js
@@ -63,6 +63,7 @@ function download(_url, dest, opts) {
         https.get(mergedOpts, response => {
             console.log('statusCode: ' + response.statusCode);
             if (response.statusCode === 302) {
+                response.resume();
                 console.log('Following redirect to: ' + response.headers.location);
                 return download(response.headers.location, dest, opts)
                     .then(resolve, reject);


### PR DESCRIPTION
Running the postinstall script takes around 30s.
It looks like https://github.com/nodejs/node/issues/47228 is the root cause.

Adding a `response.resume()` is a working workaround.