### PR TITLE
Fix for arm64 windows

### DIFF
--- a/lib/postinstall.js
+++ b/lib/postinstall.js
@@ -35,7 +35,7 @@ async function getTarget() {
                 'x86_64-apple-darwin';
         case 'win32':
             return arch === 'x64' ? 'x86_64-pc-windows-msvc' :
-                (arch === 'arm' || arch === 'arm64') ? 'aarch64-pc-windows-msvc' :
+                arch === 'arm64' ? 'aarch64-pc-windows-msvc' :
                 'i686-pc-windows-msvc';
         case 'linux':
             return arch === 'x64' ? 'x86_64-unknown-linux-musl' :

--- a/lib/postinstall.js
+++ b/lib/postinstall.js
@@ -35,7 +35,7 @@ async function getTarget() {
                 'x86_64-apple-darwin';
         case 'win32':
             return arch === 'x64' ? 'x86_64-pc-windows-msvc' :
-                arch === 'arm' ? 'aarch64-pc-windows-msvc' :
+                (arch === 'arm' || arch === 'arm64') ? 'aarch64-pc-windows-msvc' :
                 'i686-pc-windows-msvc';
         case 'linux':
             return arch === 'x64' ? 'x86_64-unknown-linux-musl' :


### PR DESCRIPTION
I installed @vscode/ripgrep when building vscode windows-arm64, and noticed the rg binary was for the wrong arch (32-bit intel).

cc @andreamah