### PR TITLE
ci: fix github token for publishing step

### DIFF
--- a/build/pipeline.yml
+++ b/build/pipeline.yml
@@ -38,9 +38,15 @@ extends:
               - 18.x
 
         buildSteps:
+          - task: AzureKeyVault@2
+            displayName: "Azure Key Vault: Get Secrets"
+            inputs:
+              azureSubscription: "vscode-oss-build-secrets"
+              KeyVaultName: "vscode-oss-build-secrets"
+              SecretsFilter: "github-token-code-oss"
           - script: npm i
             displayName: Install dependencies
             env:
-              GITHUB_TOKEN: $(github-token-public-repos)
+              GITHUB_TOKEN: $(github-token-code-oss)
 
         publishPackage: ${{ parameters.publishPackage }}


### PR DESCRIPTION
Fixes npm package publishing, refs https://dev.azure.com/monacotools/Monaco/_build/results?buildId=312427&view=results